### PR TITLE
use circular buffer for connection pool

### DIFF
--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,6 +1,6 @@
 import XCTest
 
-@testable import NIOKitTests
+import NIOKitTests
 
 var tests = [
     testCase(NIOKitTests.allTests),

--- a/Tests/NIOKitTests/ConnectionPoolTests.swift
+++ b/Tests/NIOKitTests/ConnectionPoolTests.swift
@@ -40,6 +40,7 @@ final class ConnectionPoolTests: XCTestCase {
     }
     
     func testPerformance() {
+        guard performance(expected: 3.14) else { return }
         let foo = FooDatabase()
         let pool = ConnectionPool(config: .init(maxConnections: 10), source: foo)
         
@@ -97,4 +98,13 @@ private final class FooConnection: ConnectionPoolItem {
     func close() {
         self.isClosed = true
     }
+}
+
+func performance(expected seconds: Double, name: String = #function) -> Bool {
+    guard !_isDebugAssertConfiguration() else {
+        print("[PERFORMANCE] Skipping \(name) in debug build mode")
+        return false
+    }
+    print("[PERFORMANCE] \(name) expected: \(seconds) seconds")
+    return true
 }

--- a/Tests/NIOKitTests/ConnectionPoolTests.swift
+++ b/Tests/NIOKitTests/ConnectionPoolTests.swift
@@ -68,7 +68,7 @@ public final class ConnectionPoolTests: XCTestCase {
     }
     
     func testPerformance() {
-        guard performance(expected: 0.115) else { return }
+        guard performance(expected: 0.088) else { return }
         let foo = FooDatabase()
         let pool = ConnectionPool(config: .init(maxConnections: 10), source: foo)
         

--- a/Tests/NIOKitTests/ConnectionPoolTests.swift
+++ b/Tests/NIOKitTests/ConnectionPoolTests.swift
@@ -1,7 +1,7 @@
 import NIOKit
 import XCTest
 
-final class ConnectionPoolTests: XCTestCase {
+public final class ConnectionPoolTests: XCTestCase {
     func testPooling() throws {
         let foo = FooDatabase()
         let pool = ConnectionPool(config: .init(maxConnections: 2), source: foo)
@@ -68,7 +68,7 @@ final class ConnectionPoolTests: XCTestCase {
         }
     }
     
-    static let allTests = [
+    public static let allTests = [
         ("testPooling", testPooling),
         ("testPerformance", testPerformance),
     ]

--- a/Tests/NIOKitTests/ConnectionPoolTests.swift
+++ b/Tests/NIOKitTests/ConnectionPoolTests.swift
@@ -39,6 +39,34 @@ public final class ConnectionPoolTests: XCTestCase {
         XCTAssertEqual(foo.connectionsCreated, 3)
     }
     
+    func testFIFOWaiters() throws {
+        let foo = FooDatabase()
+        let pool = ConnectionPool(config: .init(maxConnections: 1), source: foo)
+        // * User A makes a request for a connection, gets connection number 1.
+        let a_1 = pool.requestConnection()
+        let a = try a_1.wait()
+        
+        // * User B makes a request for a connection, they are exhausted so he gets a promise.
+        let b_1 = pool.requestConnection()
+        
+        // * User A makes another request for a connection, they are still exhausted so he gets a promise.
+        let a_2 = pool.requestConnection()
+        
+        // * User A returns connection number 1. His previous request is fulfilled with connection number 1.
+        pool.releaseConnection(a)
+        
+        // * User B gets his connection
+        let b = try b_1.wait()
+        XCTAssert(a === b)
+        
+        // * User B releases his connection
+        pool.releaseConnection(b)
+        
+        // * User A's second connection request is fulfilled
+        let c = try a_2.wait()
+        XCTAssert(a === c)
+    }
+    
     func testPerformance() {
         guard performance(expected: 0.115) else { return }
         let foo = FooDatabase()
@@ -70,6 +98,7 @@ public final class ConnectionPoolTests: XCTestCase {
     
     public static let allTests = [
         ("testPooling", testPooling),
+        ("testFIFOWaiters", testFIFOWaiters),
         ("testPerformance", testPerformance),
     ]
 }

--- a/Tests/NIOKitTests/ConnectionPoolTests.swift
+++ b/Tests/NIOKitTests/ConnectionPoolTests.swift
@@ -40,7 +40,7 @@ public final class ConnectionPoolTests: XCTestCase {
     }
     
     func testPerformance() {
-        guard performance(expected: 3.14) else { return }
+        guard performance(expected: 0.115) else { return }
         let foo = FooDatabase()
         let pool = ConnectionPool(config: .init(maxConnections: 10), source: foo)
         

--- a/Tests/NIOKitTests/FutureOperatorsTests.swift
+++ b/Tests/NIOKitTests/FutureOperatorsTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import NIO
-@testable import NIOKit
+import NIOKit
 
 public final class FutureOperatorTests: XCTestCase {
     private var group: EventLoopGroup!

--- a/Tests/NIOKitTests/FutureOperatorsTests.swift
+++ b/Tests/NIOKitTests/FutureOperatorsTests.swift
@@ -2,18 +2,18 @@ import XCTest
 import NIO
 @testable import NIOKit
 
-final class FutureOperatorTests: XCTestCase {
+public final class FutureOperatorTests: XCTestCase {
     private var group: EventLoopGroup!
     private var eventLoop: EventLoop {
         return group.next()
     }
     
-    override func setUp() {
+    public override func setUp() {
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         
     }
     
-    override func tearDown() {
+    public override func tearDown() {
         XCTAssertNoThrow(try self.group.syncShutdownGracefully())
         self.group = nil
     }
@@ -149,7 +149,7 @@ final class FutureOperatorTests: XCTestCase {
         XCTAssertEqual(try ~future1.wait(), 0b11110000)
     }
     
-    static var allTests = [
+    public static var allTests = [
         ("testAddition", testAddition), ("testSubtraction", testSubtraction), ("testMultiplication", testMultiplication),
         ("testModulo", testModulo), ("testDivision", testDivision), ("testComparison", testComparison), ("testBitshifts", testBitshifts),
         ("testAND", testAND), ("testXOR", testXOR), ("testOR", testOR), ("testNOT", testNOT)

--- a/Tests/NIOKitTests/FutureOperatorsTests.swift
+++ b/Tests/NIOKitTests/FutureOperatorsTests.swift
@@ -2,7 +2,7 @@ import XCTest
 import NIO
 import NIOKit
 
-final class FutureOperatorTests: NIOKitTestCase {    
+public final class FutureOperatorTests: NIOKitTestCase {    
     func testAddition() throws {
         var future1 = eventLoop.makeSucceededFuture(8)
         let future2 = eventLoop.makeSucceededFuture(5)

--- a/Tests/NIOKitTests/NIOKitTests.swift
+++ b/Tests/NIOKitTests/NIOKitTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import NIOKit
+import NIOKit
 
 public final class NIOKitTests: XCTestCase {
     func testUniverseSanity() {

--- a/Tests/NIOKitTests/NIOKitTests.swift
+++ b/Tests/NIOKitTests/NIOKitTests.swift
@@ -1,12 +1,12 @@
 import XCTest
 @testable import NIOKit
 
-final class NIOKitTests: XCTestCase {
+public final class NIOKitTests: XCTestCase {
     func testUniverseSanity() {
         XCTAssert(true)
     }
 
-    static let allTests = [
+    public static let allTests = [
         ("testUniverseSanity", testUniverseSanity)
     ]
 }

--- a/Tests/NIOKitTests/NIOKitTests.swift
+++ b/Tests/NIOKitTests/NIOKitTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 import NIOKit
 
-final class NIOKitTests: NIOKitTestCase {
+public final class NIOKitTests: NIOKitTestCase {
     func testUniverseSanity() {
         print(self.eventLoop)
         XCTAssert(true)

--- a/circle.yml
+++ b/circle.yml
@@ -8,13 +8,18 @@ jobs:
       - checkout
       - run: swift build
       - run: swift test
-
   linux-release:
     docker:
       - image: codevapor/swift:5.0
     steps:
       - checkout
       - run: swift build -c release
+  linux-performance:
+    docker:
+      - image: codevapor/swift:5.0
+    steps:
+      - checkout
+      - run: swift test -c release
 
 workflows:
   version: 2
@@ -22,3 +27,4 @@ workflows:
     jobs:
       - linux
       - linux-release
+      - linux-performance


### PR DESCRIPTION
Changes `ConnectionPool` storage from `Array` to `CircularBuffer`. 