### PR TITLE
Add guard future extension

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.0
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:4.2
 import PackageDescription
 
 let package = Package(

--- a/Sources/NIOKit/FutureExtensions.swift
+++ b/Sources/NIOKit/FutureExtensions.swift
@@ -1,7 +1,18 @@
-// MARK: - Guard
-
 public extension EventLoopFuture {
-    /// Guards that the future's value satisfies the callback's condition or fails with the given error.
+    // MARK: - Guard
+    
+    /// Guards that the future's value satisfies the callback's condition or
+    /// fails with the given error.
+    ///
+    ///
+    /// Example usage:
+    ///
+    ///     future.guard({ $0.userID == user.id }, else: AccessError.unauthorized)
+    ///
+    /// - parameters:
+    ///   - callback: Callback that asynchronously executes a condition.
+    ///   - error: The error to fail with if condition isn't met.
+    /// - returns: A future containing the original future's result.
     func `guard`(_ callback: @escaping ((Value) -> Bool), else error: @escaping @autoclosure () -> Error) -> EventLoopFuture<Value> {
         let promise = self.eventLoop.makePromise(of: Value.self)
         self.whenComplete { result in

--- a/Sources/NIOKit/FutureExtensions.swift
+++ b/Sources/NIOKit/FutureExtensions.swift
@@ -3,8 +3,8 @@
 public extension EventLoopFuture {
     /// Guards that the future's value satisfies the callback's condition or fails with the given error.
     func `guard`(_ callback: @escaping ((Value) -> Bool), else error: @escaping @autoclosure () -> Error) -> EventLoopFuture<Value> {
-        let promise = eventLoop.makePromise(of: Value.self)
-        whenComplete { result in
+        let promise = self.eventLoop.makePromise(of: Value.self)
+        self.whenComplete { result in
             switch result {
             case .success(let value):
                 if callback(value) {

--- a/Sources/NIOKit/FutureExtensions.swift
+++ b/Sources/NIOKit/FutureExtensions.swift
@@ -1,13 +1,17 @@
 // MARK: - Guard
 
 public extension EventLoopFuture {
-	/// Guards that the future's value satisfies the callback's condition or fails with the given error.
-	func `guard`(_ callback: @escaping ((Value) -> Bool), else error: Error) -> EventLoopFuture<Value> {
-		let promise = eventLoop.makePromise(of: Value.self)
-		whenSuccess {
-			if callback($0) { promise.succeed($0) } else { promise.fail(error) }
-		}
-		whenFailure { promise.fail($0) }
-		return promise.futureResult
-	}
+    /// Guards that the future's value satisfies the callback's condition or fails with the given error.
+    func `guard`(_ callback: @escaping ((Value) -> Bool), else error: @escaping @autoclosure () -> Error) -> EventLoopFuture<Value> {
+        let promise = eventLoop.makePromise(of: Value.self)
+        whenComplete { result in
+            switch result {
+            case .success(let value):
+                if callback(value) { promise.succeed(value) }
+                else { promise.fail(error()) }
+            case .failure(let error): promise.fail(error)
+            }
+        }
+        return promise.futureResult
+    }
 }

--- a/Sources/NIOKit/FutureExtensions.swift
+++ b/Sources/NIOKit/FutureExtensions.swift
@@ -1,0 +1,13 @@
+// MARK: - Guard
+
+public extension EventLoopFuture {
+	/// Guards that the future's value satisfies the callback's condition or fails with the given error.
+	func `guard`(_ callback: @escaping ((Value) -> Bool), else error: Error) -> EventLoopFuture<Value> {
+		let promise = eventLoop.makePromise(of: Value.self)
+		whenSuccess {
+			if callback($0) { promise.succeed($0) } else { promise.fail(error) }
+		}
+		whenFailure { promise.fail($0) }
+		return promise.futureResult
+	}
+}

--- a/Sources/NIOKit/FutureExtensions.swift
+++ b/Sources/NIOKit/FutureExtensions.swift
@@ -7,8 +7,11 @@ public extension EventLoopFuture {
         whenComplete { result in
             switch result {
             case .success(let value):
-                if callback(value) { promise.succeed(value) }
-                else { promise.fail(error()) }
+                if callback(value) {
+                    promise.succeed(value)
+                } else {
+                    promise.fail(error())
+                }
             case .failure(let error): promise.fail(error)
             }
         }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -5,6 +5,7 @@ import XCTest
 var tests = [
     testCase(NIOKitTests.allTests),
     testCase(FutureOperatorTests.allTests),
-    testCase(ConnectionPoolTests.allTests)
+    testCase(ConnectionPoolTests.allTests),
+    testCase(FutureExtensionsTests.allTests)
 ]
 XCTMain(tests)

--- a/Tests/NIOKitTests/FutureExtensionsTests.swift
+++ b/Tests/NIOKitTests/FutureExtensionsTests.swift
@@ -2,22 +2,7 @@ import XCTest
 import NIO
 @testable import NIOKit
 
-final class FutureExtensionsTests: XCTestCase {
-    private var group: EventLoopGroup!
-    
-    private var eventLoop: EventLoop {
-        return group.next()
-    }
-    
-    override func setUp() {
-        group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-    }
-    
-    override func tearDown() {
-        XCTAssertNoThrow(try group.syncShutdownGracefully())
-        group = nil
-    }
-    
+final class FutureExtensionsTests: NIOKitTestCase {
     func testGuard() {
         let future1 = eventLoop.makeSucceededFuture(1)
         let guardedFuture1 = future1.guard({ $0 == 1 }, else: TestError.notEqualTo1)

--- a/Tests/NIOKitTests/FutureExtensionsTests.swift
+++ b/Tests/NIOKitTests/FutureExtensionsTests.swift
@@ -29,7 +29,7 @@ final class FutureExtensionsTests: XCTestCase {
     }
     
     static var allTests = [
-        ("testGuard", testGuard)
+        ("testGuard", testGuard),
     ]
 }
 

--- a/Tests/NIOKitTests/FutureExtensionsTests.swift
+++ b/Tests/NIOKitTests/FutureExtensionsTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+import NIO
+@testable import NIOKit
+
+final class FutureExtensionsTests: XCTestCase {
+	private var group: EventLoopGroup!
+	private var eventLoop: EventLoop { return group.next() }
+    
+    override func setUp() {
+        group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+	}
+    
+    override func tearDown() {
+        XCTAssertNoThrow(try group.syncShutdownGracefully())
+        group = nil
+	}
+	
+	func testGuard() {
+		let future1 = eventLoop.makeSucceededFuture(1)
+		let guardedFuture1 = future1.guard({ $0 == 1 }, else: TestError.notEqualTo1)
+		XCTAssertNoThrow(try guardedFuture1.wait())
+		
+		let future2 = eventLoop.makeSucceededFuture("foo")
+		let guardedFuture2 = future2.guard({ $0 == "bar" }, else: TestError.notEqualToBar)
+		XCTAssertThrowsError(try guardedFuture2.wait())
+	}
+	
+	static var allTests = [("testGuard", testGuard)]
+}
+
+enum TestError: Error {
+	case notEqualTo1
+	case notEqualToBar
+}

--- a/Tests/NIOKitTests/FutureExtensionsTests.swift
+++ b/Tests/NIOKitTests/FutureExtensionsTests.swift
@@ -3,32 +3,37 @@ import NIO
 @testable import NIOKit
 
 final class FutureExtensionsTests: XCTestCase {
-	private var group: EventLoopGroup!
-	private var eventLoop: EventLoop { return group.next() }
+    private var group: EventLoopGroup!
+    
+    private var eventLoop: EventLoop {
+        return group.next()
+    }
     
     override func setUp() {
         group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-	}
+    }
     
     override func tearDown() {
         XCTAssertNoThrow(try group.syncShutdownGracefully())
         group = nil
-	}
-	
-	func testGuard() {
-		let future1 = eventLoop.makeSucceededFuture(1)
-		let guardedFuture1 = future1.guard({ $0 == 1 }, else: TestError.notEqualTo1)
-		XCTAssertNoThrow(try guardedFuture1.wait())
-		
-		let future2 = eventLoop.makeSucceededFuture("foo")
-		let guardedFuture2 = future2.guard({ $0 == "bar" }, else: TestError.notEqualToBar)
-		XCTAssertThrowsError(try guardedFuture2.wait())
-	}
-	
-	static var allTests = [("testGuard", testGuard)]
+    }
+    
+    func testGuard() {
+        let future1 = eventLoop.makeSucceededFuture(1)
+        let guardedFuture1 = future1.guard({ $0 == 1 }, else: TestError.notEqualTo1)
+        XCTAssertNoThrow(try guardedFuture1.wait())
+        
+        let future2 = eventLoop.makeSucceededFuture("foo")
+        let guardedFuture2 = future2.guard({ $0 == "bar" }, else: TestError.notEqualToBar)
+        XCTAssertThrowsError(try guardedFuture2.wait())
+    }
+    
+    static var allTests = [
+        ("testGuard", testGuard)
+    ]
 }
 
 enum TestError: Error {
-	case notEqualTo1
-	case notEqualToBar
+    case notEqualTo1
+    case notEqualToBar
 }


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! --->

<!-- Provide a brief description of the PR here. -->
<!-- Pretend you are explaining it to a friend, not yourself! -->
Mimics the simple `guard` statement in Swift. Useful for verifying a condition of the future before moving forward.

Example usage:
```swift
.guard({ order.userID == user.id }, else: AccessError.unauthorized)
```

### Checklist

<!-- The items on this checklist must be completed to merge. -->

- [x] Circle CI is passing (code compiles and passes tests).
- [x] There are no breaking changes to public API.
- [x] New test cases have been added where appropriate.
- [x] All new code has been commented with doc blocks `///`.