### PR TITLE
Wrap the argument to `Future.transform` in an autoclosure

### DIFF
--- a/Sources/NIOKit/Transform.swift
+++ b/Sources/NIOKit/Transform.swift
@@ -5,9 +5,9 @@ extension EventLoopFuture {
     ///
     ///     user.save(on: req).transform(to: HTTPStatus.created)
     ///
-    public func transform<T>(to instance: T) -> EventLoopFuture<T> {
+    public func transform<T>(to instance: @escaping @autoclosure () -> T) -> EventLoopFuture<T> {
         return self.map { _ in
-            instance
+            instance()
         }
     }
     


### PR DESCRIPTION
This avoids creating the argument if it won't be needed at all, e.g. because a previous future fails.