### PR TITLE
Add checkbox for `swift test --generate-linuxmain`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,3 +11,4 @@
 - [ ] There are no breaking changes to public API.
 - [ ] New test cases have been added where appropriate.
 - [ ] All new code has been commented with doc blocks `///`.
+- [ ] The linuxMain.swift is regenerated using `swift test --generate-linuxmain`


### PR DESCRIPTION
Adds a checkbox to the PR template so the linuxmain is regenerated every time new tests are added, to prevent us from missing tests on Linux on accident.