### PR TITLE
add ConnectionPool.close() + fix connect error bug

### DIFF
--- a/Sources/NIOKit/ConnectionPool.swift
+++ b/Sources/NIOKit/ConnectionPool.swift
@@ -65,12 +65,12 @@ public final class ConnectionPool<Source> where Source: ConnectionPoolSource  {
     /// Creates new connections when needed. See `ConnectionPoolSource`.
     public let source: Source
     
-    /// This ConnectionPool's event loop.
+    /// This connection pool's event loop.
     public var eventLoop: EventLoop {
         return self.source.eventLoop
     }
     
-    /// If `true`, this ConnectionPool has been closed.
+    /// If `true`, this connection pool has been closed.
     public private(set) var isClosed: Bool
     
     // MARK: Private
@@ -210,7 +210,8 @@ public final class ConnectionPool<Source> where Source: ConnectionPoolSource  {
     /// Any connections currently in use will be closed when they are returned to the pool.
     ///
     /// Once closed, the connection pool cannot be used to create new connections.
-    /// Connection pools _must_ be closed before the deinitialize.
+    ///
+    /// Connection pools must be closed before they deinitialize.
     ///
     /// - returns: A future indicating close completion.
     public func close() -> EventLoopFuture<Void> {

--- a/Sources/NIOKit/ConnectionPool.swift
+++ b/Sources/NIOKit/ConnectionPool.swift
@@ -214,13 +214,13 @@ public final class ConnectionPool<Source> where Source: ConnectionPoolSource  {
     ///
     /// - returns: A future indicating close completion.
     public func close() -> EventLoopFuture<Void> {
+        self.isClosed = true
         return self.available.map { $0.close() }.flatten(on: self.eventLoop).map {
             while let waiter = self.waiters.popFirst() {
                 waiter.fail(ConnectionPoolError.closed)
             }
             self.available = []
             self.activeConnections = 0
-            self.isClosed = true
         }
     }
     

--- a/Sources/NIOKit/EventLoopFuture/Collection+Flatten.swift
+++ b/Sources/NIOKit/EventLoopFuture/Collection+Flatten.swift
@@ -1,7 +1,6 @@
 import NIO
 
 extension Collection {
-    
     /// Converts a collection of `EventLoopFuture`s to an `EventLoopFuture` that wraps an array with the future values.
     ///
     /// Acts as a helper for the `EventLoop.flatten(_:[EventLoopFuture<Value>])` method.
@@ -12,7 +11,25 @@ extension Collection {
     ///
     /// - parameter eventLoop: The event-loop to succeed the futures on.
     /// - returns: The succeeded values in an array, wrapped in an `EventLoopFuture`.
-    public func flatten<Value>(on eventLoop: EventLoop) -> EventLoopFuture<[Value]> where Element == EventLoopFuture<Value> {
+    public func flatten<Value>(on eventLoop: EventLoop) -> EventLoopFuture<[Value]>
+        where Element == EventLoopFuture<Value>
+    {
         return eventLoop.flatten(Array(self))
+    }
+}
+
+extension Array where Element == EventLoopFuture<Void> {
+    /// Converts a collection of `EventLoopFuture<Void>`s to an `EventLoopFuture<Void>`.
+    ///
+    /// Acts as a helper for the `EventLoop.flatten(_:[EventLoopFuture<Value>])` method.
+    ///
+    ///     let futures = [el.future(1), el.future(2), el.future(3), el.future(4)]
+    ///     let flattened = futures.flatten(on: el)
+    ///     // flattened: EventLoopFuture<Void>
+    ///
+    /// - parameter eventLoop: The event-loop to succeed the futures on.
+    /// - returns: The succeeded future.
+    public func flatten(on eventLoop: EventLoop) -> EventLoopFuture<Void> {
+        return .andAllSucceed(self, on: eventLoop)
     }
 }

--- a/Tests/NIOKitTests/ConnectionPoolTests.swift
+++ b/Tests/NIOKitTests/ConnectionPoolTests.swift
@@ -102,7 +102,7 @@ public final class ConnectionPoolTests: XCTestCase {
         do {
             _ = try b.wait()
             XCTFail("should not have created connection")
-        } catch _ as ConnectionPoolError {
+        } catch ConnectionPoolError.closed {
             // pass
         }
         
@@ -110,7 +110,7 @@ public final class ConnectionPoolTests: XCTestCase {
         do {
             _ = try c.wait()
             XCTFail("should not have created connection")
-        } catch _ as ConnectionPoolError {
+        } catch ConnectionPoolError.closed {
             // pass
         }
     }

--- a/Tests/NIOKitTests/ConnectionPoolTests.swift
+++ b/Tests/NIOKitTests/ConnectionPoolTests.swift
@@ -5,6 +5,7 @@ public final class ConnectionPoolTests: XCTestCase {
     func testPooling() throws {
         let foo = FooDatabase()
         let pool = ConnectionPool(config: .init(maxConnections: 2), source: foo)
+        defer { try! pool.close().wait() }
         
         // make two connections
         let connA = try pool.requestConnection().wait()
@@ -32,7 +33,7 @@ public final class ConnectionPoolTests: XCTestCase {
         XCTAssertEqual(foo.connectionsCreated, 2)
         
         // this time, close the connection before releasing it
-        connC!.close()
+        try connC!.close().wait()
         pool.releaseConnection(connC!)
         XCTAssert(connD !== connB)
         XCTAssertEqual(connD?.isClosed, false)
@@ -42,6 +43,7 @@ public final class ConnectionPoolTests: XCTestCase {
     func testFIFOWaiters() throws {
         let foo = FooDatabase()
         let pool = ConnectionPool(config: .init(maxConnections: 1), source: foo)
+        defer { try! pool.close().wait() }
         // * User A makes a request for a connection, gets connection number 1.
         let a_1 = pool.requestConnection()
         let a = try a_1.wait()
@@ -65,6 +67,52 @@ public final class ConnectionPoolTests: XCTestCase {
         // * User A's second connection request is fulfilled
         let c = try a_2.wait()
         XCTAssert(a === c)
+    }
+    
+    
+    func testConnectError() throws {
+        let db = ErrorDatabase()
+        let pool = ConnectionPool(config: .init(maxConnections: 1), source: db)
+        defer { try! pool.close().wait() }
+        do {
+            _ = try pool.requestConnection().wait()
+            XCTFail("should not have created connection")
+        } catch _ as ErrorDatabase.Error {
+            // pass
+        }
+        
+        // test that we can still make another request even after a failed request
+        do {
+            _ = try pool.requestConnection().wait()
+            XCTFail("should not have created connection")
+        } catch _ as ErrorDatabase.Error {
+            // pass
+        }
+    }
+    
+    func testPoolClose() throws {
+        let foo = FooDatabase()
+        let pool = ConnectionPool(config: .init(maxConnections: 1), source: foo)
+        let _ = try pool.requestConnection().wait()
+        let b = pool.requestConnection()
+        try pool.close().wait()
+        let c = pool.requestConnection()
+        
+        // check that waiters are failed
+        do {
+            _ = try b.wait()
+            XCTFail("should not have created connection")
+        } catch _ as ConnectionPoolError {
+            // pass
+        }
+        
+        // check that new requests fail
+        do {
+            _ = try c.wait()
+            XCTFail("should not have created connection")
+        } catch _ as ConnectionPoolError {
+            // pass
+        }
     }
     
     func testPerformance() {
@@ -95,12 +143,20 @@ public final class ConnectionPoolTests: XCTestCase {
             }
         }
     }
+}
+
+private struct ErrorDatabase: ConnectionPoolSource {
+    enum Error: Swift.Error {
+        case test
+    }
     
-    public static let allTests = [
-        ("testPooling", testPooling),
-        ("testFIFOWaiters", testFIFOWaiters),
-        ("testPerformance", testPerformance),
-    ]
+    var eventLoop: EventLoop {
+        return EmbeddedEventLoop()
+    }
+    
+    func makeConnection() -> EventLoopFuture<FooConnection> {
+        return self.eventLoop.makeFailedFuture(Error.test)
+    }
 }
 
 private final class FooDatabase: ConnectionPoolSource {
@@ -124,8 +180,9 @@ private final class FooConnection: ConnectionPoolItem {
         self.isClosed = false
     }
     
-    func close() {
+    func close() -> EventLoopFuture<Void> {
         self.isClosed = true
+        return EmbeddedEventLoop().makeSucceededFuture(())
     }
 }
 

--- a/Tests/NIOKitTests/XCTestManifests.swift
+++ b/Tests/NIOKitTests/XCTestManifests.swift
@@ -6,8 +6,10 @@ extension ConnectionPoolTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__ConnectionPoolTests = [
+        ("testConnectError", testConnectError),
         ("testFIFOWaiters", testFIFOWaiters),
         ("testPerformance", testPerformance),
+        ("testPoolClose", testPoolClose),
         ("testPooling", testPooling),
     ]
 }

--- a/circle.yml
+++ b/circle.yml
@@ -3,20 +3,20 @@ version: 2
 jobs:
   linux:
     docker:
-      - image: codevapor/swift:5.0
+      - image: vapor/swift:5.0
     steps:
       - checkout
       - run: swift build
       - run: swift test
   linux-release:
     docker:
-      - image: codevapor/swift:5.0
+      - image: vapor/swift:5.0
     steps:
       - checkout
       - run: swift build -c release
   linux-performance:
     docker:
-      - image: codevapor/swift:5.0
+      - image: vapor/swift:5.0
     steps:
       - checkout
       - run: swift test -c release -Xswiftc -enable-testing


### PR DESCRIPTION
This PR adds a new `close()` method to `ConnectionPool`. This method is used to close all of the pool's active connections. In Vapor 4, connections  _must_ be closed before they deinitialize to ensure no memory is leaked. This change allows for connections created from a pool to follow this rule.

To help catch bugs early, connection pool will behave similarly to connections and cause an assertion failure if it deinitializes without being closed first. 

Some other notes:

I noticed that `flatten()` to `EventLoopFuture<Void>` was missing, so I added it.

There was a bug that caused connect failures to increment the active connection count without returning a connection. This has been fixed by decrementing the active connection count if creating a connection ever fails. 